### PR TITLE
Ignore hidden empty directories

### DIFF
--- a/core
+++ b/core
@@ -207,9 +207,9 @@ DELETE_EMPTY_DIR() {
     if [[ "${DELETE_EMPTY_DIR}" = "true" ]]; then
         echo -e "$(DATE_TIME) ${INFO} Deleting empty directory ..."
         if [[ "${DOWNLOAD_DIR}" =~ "${ARIA2_DOWNLOAD_DIR}" ]]; then
-            find "${ARIA2_DOWNLOAD_DIR}" ! -path "${ARIA2_DOWNLOAD_DIR}" -depth -type d -empty -exec rm -vrf {} \;
+            find "${ARIA2_DOWNLOAD_DIR}" ! -path "${ARIA2_DOWNLOAD_DIR}" ! -path '*/\.*' -depth -type d -empty -exec rm -vrf {} \;
         else
-            find "${DOWNLOAD_DIR}" -depth -type d -empty -exec rm -vrf {} \;
+            find "${DOWNLOAD_DIR}" ! -path '*/\.*' -depth -type d -empty -exec rm -vrf {} \;
         fi
     fi
 }


### PR DESCRIPTION
This is necessary for `syncthing` to work correctly, which requires a hidden `.stfolder` directory.